### PR TITLE
Allow view drawing to be extendable

### DIFF
--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -22,13 +22,22 @@ module.exports = strain()
   })
 
   .static('draw', function(fn) {
-    this.meth('draw', function(datum) {
-      if (arguments.length) {
-        this.el().datum(datum);
-      }
+    this.meth('_draw_', fn);
+  })
 
-      return fn.call(this);
-    });
+  .meth('_draw_', function() {})
+
+  .meth('draw', function(datum) {
+    if (arguments.length) {
+      this.el().datum(datum);
+    }
+
+    var parent = this._type_._super_.prototype;
+    if ('_draw_' in parent) {
+      parent._draw_.call(this);
+    }
+
+    return this._draw_();
   })
 
   .prop('el')

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -67,4 +67,30 @@ describe("sapphire.view", function() {
       expect(view.el().node()).to.equal(el.node());
     });
   });
+  
+  describe(".draw", function() {
+    it("should call its parent's draw", function() {
+      var thing = sapphire.view
+        .extend()
+        .draw(function() {
+          this.el()
+            .append('div')
+            .attr('class', 'thing')
+            .text('foo');
+        });
+
+      var subthing = thing.extend()
+        .extend()
+        .draw(function() {
+          this.el()
+            .append('div')
+            .attr('class', 'subthing')
+            .text('bar');
+        });
+
+      subthing(el).draw();
+      expect(el.select('.thing').text()).to.equal('foo');
+      expect(el.select('.subthing').text()).to.equal('bar');
+    });
+  });
 });


### PR DESCRIPTION
Views that extend other views will probably always need the drawing logic that happens in their parent's views.
