### PR TITLE
Change view enter hook to not mandate state

### DIFF
--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -33,7 +33,7 @@ module.exports = strain()
       this.el().datum(datum);
     }
 
-    if (!this.entered()) {
+    if (this.el().node() && !this.el().node().hasChildNodes()) {
       this.enter();
     }
 
@@ -53,11 +53,7 @@ module.exports = strain()
     }
 
     this._enter_();
-    this.entered(true);
   })
-
-  .prop('entered')
-  .default(false)
 
   .prop('el')
   .set(function(v) {

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -80,12 +80,37 @@ describe("sapphire.view", function() {
   });
 
   describe(".enter", function() {
-    it("should only get called on the first draw", function() {
+    it("should not get called when the selection is empty", function() {
       var enters = 0;
 
       var thing = sapphire.view.extend()
         .enter(function() {
           enters++;
+        });
+
+      var t = thing(el.select('.foo'));
+      t.draw();
+      expect(enters).to.equal(0);
+
+      t.draw();
+      expect(enters).to.equal(0);
+
+      t.draw();
+      expect(enters).to.equal(0);
+    });
+
+    it("should get called when the selection has no child nodes", function() {
+      var enters = 0;
+
+      var thing = sapphire.view.extend()
+        .enter(function() {
+          enters++;
+        })
+        .draw(function() {
+          this.el()
+            .append('div')
+            .attr('class', 'thing')
+            .text('foo');
         });
 
       var t = thing(el);


### PR DESCRIPTION
At the moment, `view.enter()` is invoked on the first draw. This doesn't work for cases where we don't want to hold onto and manage the view instance. For example, the dashboard view creates its widgets each draw to avoid needing to maintain a set of widget views.

The plan is to infer whether the view has been drawn depending on whether the view's element is empty or not.
