### PR TITLE
Remove the git 'assume unchanged' magic

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,10 +92,8 @@ gulp.task('build:develop', function() {
   if (branch !== 'develop') { return; }
 
   gulp.start('build', function() {
-    sh.exec('git update-index --no-assume-unchanged ./build/*');
     sh.exec('git add ./build');
     sh.exec('git commit -m "Build"');
-    sh.exec('git update-index --assume-unchanged ./build/*');
   });
 });
 
@@ -103,7 +101,6 @@ gulp.task('build:develop', function() {
 gulp.task('install', function() {
   if (!sh.test('-d', './.git')) { return; }
   sh.mkdir('-p', './.git/hooks');
-  sh.exec('git update-index --assume-unchanged ./build/*');
 
   var hookfile = './.git/hooks/post-merge';
   ['#!/bin/sh', 'npm run-script build:develop']


### PR DESCRIPTION
At the moment, we use a git merge hook to perform rebuilds. This means we don't need to worry about build changes. To tell git to forget about changes to build files, we've been doing weirdness like `git update-index --assume-unchanged ./build/*`. This isn't working too well though. For example, when applying stashed changes, git will complain about current changes to the build files preventing the stashed changes from being applied.

It will probably be better to just not worry about having these build files show up in the changes to the working directory.
