### PR TITLE
Configurable limit for last widget's sparkline and summary

### DIFF
--- a/src/scripts/widgets/last.js
+++ b/src/scripts/widgets/last.js
@@ -116,6 +116,10 @@ module.exports = require('./widget').extend()
 var summary = require('../view').extend()
   .prop('widget')
 
+  .prop('limit')
+  .default(2)
+  .set(function(v) { return Math.max(utils.ensure(v, 2), 2); })
+
   .init(function(widget) {
     this.widget(widget);
   })
@@ -130,7 +134,11 @@ var summary = require('../view').extend()
 
   .draw(function(el) {
     var widget = this.widget();
-    if (el.datum().length < 2) { return; }
+
+    if (el.datum().length < this.limit()) {
+      el.style('height', 0);
+      return;
+    }
 
     el.select('.diff')
       .datum(function(d) {

--- a/test/widgets/last.test.js
+++ b/test/widgets/last.test.js
@@ -349,8 +349,7 @@ describe("sapphire.widgets.last", function() {
     var last = sapphire.widgets.last();
 
     last.sparkline()
-      .limit(2)
-      .height(35);
+      .limit(2);
 
     expect(el.html()).to.be.empty;
 
@@ -391,6 +390,53 @@ describe("sapphire.widgets.last", function() {
     expect(sparkline.limit(2).limit()).to.equal(2);
     expect(sparkline.limit(3).limit()).to.equal(3);
     expect(sparkline.limit(4).limit()).to.equal(4);
+  });
+
+  it("should not display a summary under the configured limit", function() {
+    var last = sapphire.widgets.last();
+
+    last.summary()
+      .limit(2);
+
+    expect(el.html()).to.be.empty;
+
+    datum.values = [{
+      x: 123,
+      y: 234
+    }, {
+      x: 345,
+      y: 456
+    }, {
+      x: 567,
+      y: 789
+    }];
+
+    el.datum(datum)
+      .call(last);
+
+    expect(parseInt(el.selectAll('.summary').style('height')))
+      .to.be.above(0);
+
+    datum.values = [{
+      x: 1123,
+      y: 1234
+    }];
+
+    el.datum(datum)
+      .call(last);
+
+    expect(parseInt(el.selectAll('.summary').style('height')))
+      .to.equal(0);
+  });
+
+  it("should floor its summary's limit at 2", function() {
+    var summary = sapphire.widgets.last().summary();
+    expect(summary.limit(-1).limit()).to.equal(2);
+    expect(summary.limit(0).limit()).to.equal(2);
+    expect(summary.limit(1).limit()).to.equal(2);
+    expect(summary.limit(2).limit()).to.equal(2);
+    expect(summary.limit(3).limit()).to.equal(3);
+    expect(summary.limit(4).limit()).to.equal(4);
   });
 
   it("should display a diff line", function() {


### PR DESCRIPTION
A sparkline and summary isn't of much use for low intensity data.
