### PR TITLE
Document the `this` context for accessors

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,13 +19,25 @@ Accessors be can specified as their actual values:
 Or as a function that, given the current datum (``d``), index (``i``) and element
 (``this``), returns the desired value:
 
-
 .. code-block:: javascript
 
   var dashboard = sapphire.dashboard()
-    .title(function(d, i) {
-      return d.title;
+    .title(function(d, i) { return d.title; });
+
+
+Unless otherwise specified, the element used as the ``this`` context corresponds to the the DOM node(s) in the selection that the component was called on:
+
+
+.. code-block:: javascript
+  var el = d3.select('#dashboard');
+
+  var dashboard = sapphire.dashboard()
+    .widgets(function(d, i) {
+      console.log(this === el.node());  // true
+      return d.widgets;
     });
+
+  dashboard(el);
 
 
 configuration
@@ -41,12 +53,8 @@ using :func:`dashboard.types`.
   var dashboard = sapphire.dashboard();
 
   dashboard.types().get('last')
-    .values(function(d) {
-      return d.datapoints;
-    })
-    .y(function(d) {
-      return d.value;
-    });
+    .values(function(d) { return d.datapoints; })
+    .y(function(d) { return d.value; });
 
   d3.select('#dashboard')
     .datum(({


### PR DESCRIPTION
The `this` context of accessor methods often isn't what one would expect it to be (the current DOM element), so we should be documenting this better.
