### PR TITLE
Allow drawing functions to use their own function signatures

### DIFF
--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -13,15 +13,15 @@ module.exports = strain()
     el = sapphire.utils.ensureEl(el);
 
     if (el.node() && !el.node().hasChildNodes()) {
-      this.enter(el);
+      this.enter.apply(this, arguments);
     }
 
     var parent = this._type_._super_.prototype;
     if ('_draw_' in parent) {
-      parent._draw_.call(this, el);
+      parent._draw_.apply(this, arguments);
     }
 
-    return this._draw_(el);
+    return this._draw_.apply(this, arguments);
   })
 
   .meth(function enter(el) {
@@ -29,12 +29,12 @@ module.exports = strain()
 
     var parent = this._type_._super_.prototype;
     if ('_enter_' in parent) {
-      parent._enter_.call(this, el);
+      parent._enter_.apply(this, arguments);
     }
 
-    this._enter_(el);
+    this._enter_.apply(this, arguments);
   })
 
-  .invoke(function(el) {
-    return this.draw(el);
+  .invoke(function() {
+    return this.draw.apply(this, arguments);
   });

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -28,10 +28,10 @@ describe("sapphire.view", function() {
     it("should call its parent's draw", function() {
       var thing = sapphire.view
         .extend()
-        .draw(function(el) {
+        .draw(function(el, text) {
           el.append('div')
             .attr('class', 'thing')
-            .text('foo');
+            .text([text, 'foo'].join(' '));
         });
 
       var subthing = thing.extend()
@@ -42,9 +42,22 @@ describe("sapphire.view", function() {
             .text('bar');
         });
 
-      subthing().draw(el);
-      expect(el.select('.thing').text()).to.equal('foo');
+      subthing().draw(el, 'sir');
+      expect(el.select('.thing').text()).to.equal('sir foo');
       expect(el.select('.subthing').text()).to.equal('bar');
+    });
+
+    it("should be allowed to accept additional arguments", function() {
+      var thing = sapphire.view
+        .extend()
+        .draw(function(el, text) {
+          el.append('div')
+            .attr('class', 'thing')
+            .text([text, 'foo'].join(' '));
+        });
+
+      thing().draw(el, 'sir');
+      expect(el.select('.thing').text()).to.equal('sir foo');
     });
   });
 
@@ -94,10 +107,10 @@ describe("sapphire.view", function() {
     it("should call its parent's enter", function() {
       var thing = sapphire.view
         .extend()
-        .enter(function(el) {
+        .enter(function(el, text) {
           el.append('div')
             .attr('class', 'thing')
-            .text('foo');
+            .text([text, 'foo'].join(' '));
         });
 
       var subthing = thing.extend()
@@ -108,8 +121,8 @@ describe("sapphire.view", function() {
             .text('bar');
         });
 
-      subthing().draw(el);
-      expect(el.select('.thing').text()).to.equal('foo');
+      subthing().draw(el, 'sir');
+      expect(el.select('.thing').text()).to.equal('sir foo');
       expect(el.select('.subthing').text()).to.equal('bar');
     });
 
@@ -126,6 +139,19 @@ describe("sapphire.view", function() {
         });
 
       thing().draw(el);
+    });
+
+    it("should be allowed to accept additional arguments", function() {
+      var thing = sapphire.view
+        .extend()
+        .enter(function(el, text) {
+          el.append('div')
+            .attr('class', 'thing')
+            .text([text, 'foo'].join(' '));
+        });
+
+      thing().draw(el, 'sir');
+      expect(el.select('.thing').text()).to.equal('sir foo');
     });
   });
 });


### PR DESCRIPTION
Sometimes a view needs more than just the selection.
