### PR TITLE
More generic api method names

### DIFF
--- a/docs/api/widgets/last.rst
+++ b/docs/api/widgets/last.rst
@@ -147,7 +147,7 @@ value preceding it.
       .call(last);
 
 
-.. function:: last.valueFormat([fn])
+.. function:: last.yFormat([fn])
 
   Property for the formatting function to use when displaying the last ``y`` value.
   Defaults to ``d3.format(',2s')``.
@@ -155,7 +155,7 @@ value preceding it.
   .. code-block:: javascript
 
     var last = sapphire.widgets.last()
-      .valueFormat(d3.format('.2s'));
+      .yFormat(d3.format('.2s'));
 
 
 .. function:: last.diffFormat([fn])

--- a/docs/api/widgets/lines.rst
+++ b/docs/api/widgets/lines.rst
@@ -300,7 +300,7 @@ displaying each metric's title, colour and last ``y`` value.
       .call(lines);
 
 
-.. function:: lines.valueFormat([fn])
+.. function:: lines.yFormat([fn])
 
   Property for the formatting function to use when displaying the last ``y``
   value. Defaults to ``d3.format(',2s')``.
@@ -308,7 +308,7 @@ displaying each metric's title, colour and last ``y`` value.
   .. code-block:: javascript
 
     var lines = sapphire.widgets.lines()
-      .valueFormat(d3.format('.2s'));
+      .yFormat(d3.format('.2s'));
 
 
 .. function:: lines.xFormat([fn])

--- a/src/scripts/widgets/last.js
+++ b/src/scripts/widgets/last.js
@@ -24,7 +24,7 @@ module.exports = require('./widget').extend()
   .set(d3.functor)
   .default(function(d) { return d.y; })
 
-  .prop('valueFormat')
+  .prop('yFormat')
   .default(d3.format(',2s'))
 
   .prop('diffFormat')
@@ -111,7 +111,7 @@ module.exports = require('./widget').extend()
           ? self.none()
           : d.y;
       })
-      .text(this.valueFormat());
+      .text(this.yFormat());
 
     values.select('.sparkline')
       .call(this.sparkline());

--- a/src/scripts/widgets/lines.js
+++ b/src/scripts/widgets/lines.js
@@ -48,7 +48,7 @@ module.exports = require('./widget').extend()
   .prop('yTicks')
   .default(5)
 
-  .prop('valueFormat')
+  .prop('yFormat')
   .default(d3.format(',2s'))
 
   .prop('none')
@@ -278,7 +278,7 @@ var legend = require('../view').extend()
 
   .draw(function(el) {
     var none = this.widget().none();
-    var valueFormat = this.widget().valueFormat();
+    var yFormat = this.widget().yFormat();
 
     var metric = el.select('.table').selectAll('.metric')
       .data(function(d) { return d; },
@@ -308,8 +308,8 @@ var legend = require('../view').extend()
         d = d.values[d.values.length - 1];
 
         return d
-          ? valueFormat(d.y)
-          : valueFormat(none);
+          ? yFormat(d.y)
+          : yFormat(none);
       });
 
     metric.exit()

--- a/src/scripts/widgets/pie.js
+++ b/src/scripts/widgets/pie.js
@@ -48,7 +48,7 @@ module.exports = require('./widget').extend()
   .set(d3.functor)
   .default(function(r) { return 0.35 * r; })
 
-  .prop('valueFormat')
+  .prop('yFormat')
   .default(d3.format(',2s'))
 
   .prop('percentFormat')
@@ -185,7 +185,7 @@ var legend = require('../view').extend()
   })
 
   .draw(function(el) {
-    var valueFormat = this.widget().valueFormat();
+    var yFormat = this.widget().yFormat();
     var percentFormat = this.widget().percentFormat();
 
     var metric = el.select('.table').selectAll('.metric')
@@ -217,7 +217,7 @@ var legend = require('../view').extend()
       .text(function(d) { return percentFormat(d.percent); });
 
     metric.select('.value')
-      .text(function(d) { return valueFormat(d.value); });
+      .text(function(d) { return yFormat(d.value); });
 
     metric.exit()
       .remove();

--- a/test/widgets/pie.test.js
+++ b/test/widgets/pie.test.js
@@ -427,7 +427,7 @@ describe("sapphire.widgets.pie", function() {
     var format = d3.format(',4s');
 
     var pie = sapphire.widgets.pie()
-      .valueFormat(format)
+      .yFormat(format)
       .key(function(d) { return d.key; });
 
     datum.metrics[0].key = 'foo';


### PR DESCRIPTION
Our api names make sapphire seem only usable for time-based data.
