### PR TITLE
Fix dashboard re-renders

### DIFF
--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -10,7 +10,12 @@ module.exports = strain()
   .enter(function() {})
 
   .meth(function draw(el) {
+    var datum;
     el = sapphire.utils.ensureEl(el);
+
+    if (el.node()) {
+      datum = el.datum();
+    }
 
     if (el.node() && !el.node().hasChildNodes()) {
       this.enter.apply(this, arguments);
@@ -21,7 +26,11 @@ module.exports = strain()
       parent._draw_.apply(this, arguments);
     }
 
-    return this._draw_.apply(this, arguments);
+    this._draw_.apply(this, arguments);
+
+    if (typeof datum != 'undefined') {
+      el.datum(datum);
+    }
   })
 
   .meth(function enter(el) {

--- a/test/view.test.js
+++ b/test/view.test.js
@@ -59,6 +59,18 @@ describe("sapphire.view", function() {
       thing().draw(el, 'sir');
       expect(el.select('.thing').text()).to.equal('sir foo');
     });
+
+    it("should restore any originally bound datum", function() {
+      var a = {};
+      var b = {};
+
+      var thing = sapphire.view.extend()
+        .draw(function(el) { el.datum(b); });
+
+      el.datum(a);
+      thing().draw(el);
+      expect(el.datum()).to.equal(a);
+    });
   });
 
   describe(".enter", function() {


### PR DESCRIPTION
With #55 landed, dashboard re-renders break for cases where a new object has not been given before the new render.
