### PR TITLE
Remove Ubuntu font

### DIFF
--- a/src/styles/sapphire.less
+++ b/src/styles/sapphire.less
@@ -11,4 +11,5 @@
 
   color: @fg-color;
   font-family: @primary-font;
+  font-size: @primary-font-size;
 }

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -1,3 +1,4 @@
 @fg-color: #3a3a3a;
 @bg-color: #f2f2f2;
-@primary-font: 'Ubuntu', sans-serif;
+@primary-font: sans-serif;
+@primary-font-size: 14px;

--- a/src/styles/widgets/widget.less
+++ b/src/styles/widgets/widget.less
@@ -30,7 +30,6 @@
   }
 
   .table {
-    font-size: 15px;
     border-collapse: collapse;
     width: 100%;
 


### PR DESCRIPTION
Allows sapphire to be more easily embedded in other pages without style clashes. Custom font styling should rather be done wherever sapphire is to be embedded.
