### PR TITLE
Name strain methods using strings for minification

### DIFF
--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -71,7 +71,7 @@ module.exports = require('./view').extend()
         .attr('class', 'widgets');
   })
 
-  .meth(function normalize(el) {
+  .meth('normalize', function(el) {
     var self = this;
     var node = el.node();
 

--- a/src/scripts/grid.js
+++ b/src/scripts/grid.js
@@ -68,23 +68,23 @@ var grid = module.exports = strain()
     return data;
   })
 
-  .meth(function indexOffset(index) {
+  .meth('indexOffset', function(index) {
     return (index * this.scale()) + this.padding();
   })
 
-  .meth(function spanLength(span) {
+  .meth('spanLength', function(span) {
     return (span * this.scale()) - (this.padding() * 2);
   })
 
-  .meth(function offsetIndex(offset) {
+  .meth('offsetIndex', function(offset) {
     return Math.ceil((offset - this.padding()) / this.scale());
   })
 
-  .meth(function lengthSpan(len) {
+  .meth('lengthSpan', function(len) {
     return Math.ceil((len + (this.padding() * 2)) / this.scale());
   })
 
-  .static(function box(d) {
+  .static('box', function(d) {
     return {
       x1: d.col,
       x2: d.col + d.colspan - 1,
@@ -93,7 +93,7 @@ var grid = module.exports = strain()
     };
   })
 
-  .static(function uncollide(a) {
+  .static('uncollide', function(a) {
     var boxA = grid.box(a);
     
     return function(node, x1, y1, x2, y2) {
@@ -112,7 +112,7 @@ var grid = module.exports = strain()
     };
   })
 
-  .static(function intersection(a, b) {
+  .static('intersection', function(a, b) {
     return ((a.x1 <= b.x1 && b.x1 <= a.x2) && (a.y1 <= b.y1 && b.y1 <= a.y2))
         || ((b.x1 <= a.x1 && a.x1 <= b.x2) && (b.y1 <= a.y1 && a.y1 <= b.y2))
         || ((a.x1 <= b.x2 && b.x2 <= a.x2) && (a.y1 <= b.y1 && b.y1 <= a.y2))

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -74,7 +74,7 @@ utils.box = strain()
     bottom: 0
   })
 
-  .meth(function calc() {
+  .meth('calc', function() {
     var d = {};
     d.margin = this.margin();
     d.width = this.width();

--- a/src/scripts/view.js
+++ b/src/scripts/view.js
@@ -1,15 +1,15 @@
 module.exports = strain()
-  .static(function draw(fn) {
+  .static('draw', function(fn) {
     this.meth('_draw_', fn);
   })
   .draw(function() {})
 
-  .static(function enter(fn) {
+  .static('enter', function(fn) {
     this.meth('_enter_', fn);
   })
   .enter(function() {})
 
-  .meth(function draw(el) {
+  .meth('draw', function(el) {
     var datum;
     el = sapphire.utils.ensureEl(el);
 
@@ -33,7 +33,7 @@ module.exports = strain()
     }
   })
 
-  .meth(function enter(el) {
+  .meth('enter', function(el) {
     el = sapphire.utils.ensureEl(el);
 
     var parent = this._type_._super_.prototype;

--- a/src/scripts/widgets/bars.js
+++ b/src/scripts/widgets/bars.js
@@ -63,7 +63,7 @@ module.exports = require('./widget').extend()
     this.colors(d3.scale.category10());
   })
 
-  .meth(function normalize(el) {
+  .meth('normalize', function(el) {
     var self = this;
     var node = el.node();
 

--- a/src/scripts/widgets/lines.js
+++ b/src/scripts/widgets/lines.js
@@ -80,7 +80,7 @@ module.exports = require('./widget').extend()
       .attr('class', 'legend');
   })
 
-  .meth(function normalize(el) {
+  .meth('normalize', function(el) {
     var self = this;
     var node = el.node();
 

--- a/src/scripts/widgets/pie.js
+++ b/src/scripts/widgets/pie.js
@@ -52,7 +52,7 @@ module.exports = require('./widget').extend()
     this.colors(d3.scale.category10());
   })
 
-  .meth(function normalize(el) {
+  .meth('normalize', function(el) {
     var self = this;
     var node = el.node();
 

--- a/test/widgets/pie.test.js
+++ b/test/widgets/pie.test.js
@@ -10,7 +10,7 @@ describe("sapphire.widgets.pie", function() {
     .prop('innerRadius')
     .prop('data')
 
-    .meth(function radius() {
+    .meth('radius', function() {
       var dims = sapphire.utils.box()
         .margin(this.margin())
         .width(this.width())


### PR DESCRIPTION
When minifying code using uglifyjs (which is the common case) with the `unsafe` option enabled, named functions lose their names.
