### PR TITLE
Remove font family restriction

### DIFF
--- a/src/styles/theme/vars.less
+++ b/src/styles/theme/vars.less
@@ -2,4 +2,3 @@
 @bg-color: #f2f2f2;
 @good-color: #2ca02c;
 @bad-color: #d62728;
-@primary-font-size: 14px;

--- a/src/styles/theme/widgets/widget.less
+++ b/src/styles/theme/widgets/widget.less
@@ -1,4 +1,3 @@
 .sph-widget {
   color: @fg-color;
-  font-size: @primary-font-size;
 }


### PR DESCRIPTION
It might be better for sapphire widgets to not fix the font family used to allow the widgets to fit in better with whatever page they are placed on.
