### PR TITLE
More sensible default formatting functions

### DIFF
--- a/docs/api/widgets/last.rst
+++ b/docs/api/widgets/last.rst
@@ -150,7 +150,9 @@ value preceding it.
 .. function:: last.yFormat([fn])
 
   Property for the formatting function to use when displaying the last ``y`` value.
-  Defaults to ``d3.format(',2s')``.
+
+  Defaults to a function equivalent to ``d3.format(',')`` for integer values
+  and ``d3.format(',.3f')`` for float values.
 
   .. code-block:: javascript
 
@@ -161,8 +163,10 @@ value preceding it.
 .. function:: last.diffFormat([fn])
 
   Property for the formatting function to use when displaying the difference
-  between the last ``y`` value and the ``y`` value preceding it. Defaults to
-  ``d3.format('+,2s')``.
+  between the last ``y`` value and the ``y`` value preceding it.
+
+  Defaults to a function equivalent to ``d3.format('+,')`` for integer values
+  and ``d3.format('+,.3f')`` for float values.
 
   .. code-block:: javascript
 

--- a/docs/api/widgets/lines.rst
+++ b/docs/api/widgets/lines.rst
@@ -302,7 +302,10 @@ displaying each metric's title, colour and last ``y`` value.
 .. function:: lines.yFormat([fn])
 
   Property for the formatting function to use when displaying the last
-  ``y`` value. Defaults to ``d3.format(',2s')``.
+  ``y`` value.
+
+  Defaults to a function equivalent to ``d3.format(',')`` for integer values
+  and ``d3.format(',.3f')`` for float values.
 
   .. code-block:: javascript
 

--- a/docs/api/widgets/pie.rst
+++ b/docs/api/widgets/pie.rst
@@ -188,8 +188,10 @@ displaying each metric's title, colour, value and percentage.
 
 .. function:: pie.valueFormat([fn])
 
-  Property for the formatting function to use when displaying the metric
-  values in the widget's table. Defaults to ``d3.format(',2s')``.
+  Property for the formatting function to use when displaying the metric values
+  in the widget's table. Defaults to a function equivalent to
+  ``d3.format(',')`` for integer values and ``d3.format(',.3f')`` for float
+  values.
 
   .. code-block:: javascript
 

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -80,6 +80,25 @@ utils.box = strain()
   });
 
 
+utils.formatValue = strain()
+  .prop('int')
+  .default(d3.format(','))
+
+  .prop('float')
+  .default(d3.format(',.3f'))
+
+  .invoke(function(v) {
+    return utils.isInteger(v)
+      ? this.int()(v)
+      : this.float()(v);
+  });
+
+
+utils.isInteger = function(v) {
+  return +v === parseInt(v);
+};
+
+
 utils.innerWidth = function(el) {
   return utils.measure(el, 'width')
        - utils.measure(el, 'padding-left')

--- a/src/scripts/widgets/last.js
+++ b/src/scripts/widgets/last.js
@@ -19,10 +19,14 @@ module.exports = require('./widget').extend()
   .default(function(d) { return d.y; })
 
   .prop('yFormat')
-  .default(d3.format(',2s'))
+  .default(utils.formatValue()
+    .int(d3.format(','))
+    .float(d3.format(',.3f')))
 
   .prop('diffFormat')
-  .default(d3.format('+,2s'))
+  .default(utils.formatValue()
+    .int(d3.format('+,'))
+    .float(d3.format('+,.3f')))
 
   .prop('xFormat')
   .default(d3.time.format('%-d %b %-H:%M'))

--- a/src/scripts/widgets/lines.js
+++ b/src/scripts/widgets/lines.js
@@ -37,7 +37,9 @@ module.exports = require('./widget').extend()
   .default(8)
 
   .prop('yFormat')
-  .default(d3.format(',2s'))
+  .default(utils.formatValue()
+    .int(d3.format(','))
+    .float(d3.format(',.3f')))
 
   .prop('yTicks')
   .default(5)

--- a/src/scripts/widgets/pie.js
+++ b/src/scripts/widgets/pie.js
@@ -37,7 +37,9 @@ module.exports = require('./widget').extend()
   .default(0)
 
   .prop('valueFormat')
-  .default(d3.format(',2s'))
+  .default(utils.formatValue()
+    .int(d3.format(','))
+    .float(d3.format(',.3f')))
 
   .prop('percentFormat')
   .default(d3.format('.0%'))

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -169,4 +169,32 @@ describe("sapphire.utils", function() {
       expect(sapphire.utils.innerHeight(el)).to.equal(192);
     });
   });
+
+  describe(".isInteger", function() {
+    it("should determine whether the value is an integer", function() {
+      expect(sapphire.utils.isInteger(23)).to.be.true;
+      expect(sapphire.utils.isInteger('23')).to.be.true;
+      //expect(sapphire.utils.isInteger(23.23)).to.be.false;
+      //expect(sapphire.utils.isInteger('23.23')).to.be.false;
+      //expect(sapphire.utils.isInteger('o_O')).to.be.false;
+    });
+  });
+
+  describe(".formatValue", function() {
+    it("should use the float formatter if the value is a float", function() {
+      var fn = sapphire.utils.formatValue()
+        .int(function(v) { return v + '.'; })
+        .float(function(v) { return v + '!'; });
+
+      expect(fn(23.23)).to.equal('23.23!');
+    });
+
+    it("should use the integer formatter if the value is a float", function() {
+      var fn = sapphire.utils.formatValue()
+        .int(function(v) { return v + '!'; })
+        .float(function(v) { return v + '.'; });
+
+      expect(fn(23)).to.equal('23!');
+    });
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -174,9 +174,9 @@ describe("sapphire.utils", function() {
     it("should determine whether the value is an integer", function() {
       expect(sapphire.utils.isInteger(23)).to.be.true;
       expect(sapphire.utils.isInteger('23')).to.be.true;
-      //expect(sapphire.utils.isInteger(23.23)).to.be.false;
-      //expect(sapphire.utils.isInteger('23.23')).to.be.false;
-      //expect(sapphire.utils.isInteger('o_O')).to.be.false;
+      expect(sapphire.utils.isInteger(23.23)).to.be.false;
+      expect(sapphire.utils.isInteger('23.23')).to.be.false;
+      expect(sapphire.utils.isInteger('o_O')).to.be.false;
     });
   });
 


### PR DESCRIPTION
At the moment, the default formatting functions don't limit the number of digits after the decimal point.